### PR TITLE
Changes to migrate to v3.

### DIFF
--- a/lib/hooks/connectorHook.js
+++ b/lib/hooks/connectorHook.js
@@ -46,7 +46,7 @@ var loadHooks = function(app, config) {
 
         connector.observe('after execute', function(ctx, next) {
             debug('connector after execute for',name);
-            var loopbackContext = app.loopback.getCurrentContext();
+            var loopbackContext = ctx;
             if(loopbackContext && loopbackContext.active && loopbackContext.active.http) {
                 var httpContext = loopbackContext.active.http;
                 var key = connectorObj[type] && connectorObj[type](ctx,name);

--- a/lib/loggerModel.js
+++ b/lib/loggerModel.js
@@ -15,12 +15,12 @@ exports.addModel = function(app) {
         }
     });
 
-    loggerModel.disableRemoteMethod('create', true);
-    loggerModel.disableRemoteMethod('deleteById', true);
-    loggerModel.disableRemoteMethod('upsert', true);
-    loggerModel.disableRemoteMethod('exists', true);
-    loggerModel.disableRemoteMethod('findOne', true);
-    loggerModel.disableRemoteMethod('createChangeStream',true);
+    loggerModel.disableRemoteMethodByName('create', true);
+    loggerModel.disableRemoteMethodByName('deleteById', true);
+    loggerModel.disableRemoteMethodByName('upsert', true);
+    loggerModel.disableRemoteMethodByName('exists', true);
+    loggerModel.disableRemoteMethodByName('findOne', true);
+    loggerModel.disableRemoteMethodByName('createChangeStream',true);
 
     app.model(loggerModel,{
       'public' : true,


### PR DESCRIPTION
Using, disableRemoteMethodByName instead of disableRemoteMethod, as the latter is deprecated. 
Fixing Error: loopback.getCurrentContext() was removed in version 3.